### PR TITLE
Fixed pack traceheader error

### DIFF
--- a/toolkit.py
+++ b/toolkit.py
@@ -691,7 +691,7 @@ def write_trace_header(fh, trace_header, trace_header_format, pos=None):
     """
     if pos is not None:
         fh.seek(pos, os.SEEK_SET)
-    buf = trace_header_format.pack(trace_header)
+    buf = trace_header_format.pack(*trace_header)
     fh.write(buf)
 
 


### PR DESCRIPTION
In python 3.3 I got the error: "pack expected 91 items for packing (got 1)", which is fixed if I pass the traceheader's items in as separate arguments (by adding an *).